### PR TITLE
Automated Alembic Migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /rescue
 
 COPY requirements.txt requirements.txt
 
+RUN apt-get update && apt-get install -f -y postgresql-client
+
 RUN pip install --no-cache-dir --upgrade -r /rescue/requirements.txt
 
 COPY alembic/ ./alembic/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - db
     volumes:
       - ./be-data/:/backend/
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     env_file:
       - .env
     ports:

--- a/startup.sh
+++ b/startup.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 
-# Is the database read to accept connections?
-# If the database is not ready to accept connections and this script proceeds regardless, the Docker container will crash.
-# while [pg_isready -h db -p 5432 == ] do
-#   sleep 1
-# done
+while ! pg_isready 
+do
+    echo "$(date) - waiting for database to start"
+    sleep 10
+done
 
 # # Run all migrations on the database.
-# alembic upgrade head
+alembic upgrade head
+
+# until alembic upgrade head; do sleep 10; done
 
 # start the server
 uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,5 @@ done
 # # Run all migrations on the database.
 alembic upgrade head
 
-# until alembic upgrade head; do sleep 10; done
-
 # start the server
 uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/startup.sh
+++ b/startup.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-while ! pg_isready 
+while ! pg_isready -h "db" -p 5432
 do
     echo "$(date) - waiting for database to start"
-    sleep 10
+    sleep 5
 done
 
 # # Run all migrations on the database.

--- a/startup.sh
+++ b/startup.sh
@@ -8,3 +8,6 @@ done
 
 # Run all migrations on the database.
 alembic upgrade head
+
+# start the server
+uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/startup.sh
+++ b/startup.sh
@@ -2,12 +2,12 @@
 
 # Is the database read to accept connections?
 # If the database is not ready to accept connections and this script proceeds regardless, the Docker container will crash.
-while ! mysqladmin ping -h"database" --silent; do
-  sleep 1
-done
+# while [pg_isready -h db -p 5432 == ] do
+#   sleep 1
+# done
 
-# Run all migrations on the database.
-alembic upgrade head
+# # Run all migrations on the database.
+# alembic upgrade head
 
 # start the server
 uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This PR automates alembic migrations at the start of each container build in docker. While this is not normally considered ["best practice"](https://pythonspeed.com/articles/schema-migrations-server-startup/) I think for our purposes this will be really helpful in abstracting a lot of setup for people who won't be messing with the backend. Overall im really happy with this automation.